### PR TITLE
Reference MicroOS instead of Kubic

### DIFF
--- a/templates/modal.tt2
+++ b/templates/modal.tt2
@@ -12,7 +12,7 @@
 		  <fieldset data-role="controlgroup" data-type="vertical" id="pull_command_selector" name="pull_command_selector">
 		    <div class="custom-control custom-radio">
 		      <input type="radio" id="podman" name="pull_command" value="podman" checked="checked" class="custom-control-input">
-		      <label for="podman" class="custom-control-label"> podman - the default in openSUSE Kubic</label>
+		      <label for="podman" class="custom-control-label"> podman - the default in openSUSE MicroOS</label>
 		    </div>
 		    <div class="custom-control custom-radio">
 		      <input type="radio" id="docker" name="pull_command" value="docker" class="custom-control-input">


### PR DESCRIPTION
openSUSE Kubic has been discontinued (see https://kubic.opensuse.org/blog/2022-06-10-kubic-retired/). The successor is openSUSE MicroOS which also contains Podman by default.