### PR TITLE
Fix dark theme jumbotron

### DIFF
--- a/themes/opensuse/css/chameleon.css
+++ b/themes/opensuse/css/chameleon.css
@@ -12802,6 +12802,10 @@ body {
     color: #adb5bd;
   }
 
+  .jumbotron {
+    background-color: #212529;
+  }
+
   .breadcrumb {
     background-color: #343a40;
   }


### PR DESCRIPTION
Before:

![image](https://github.com/openSUSE/cooverview/assets/1251067/1df2d42f-2fa5-4179-a4c0-bc1e30fe3e79) 

After: 

![image](https://github.com/openSUSE/cooverview/assets/1251067/a1af7ab2-548c-434f-8468-f88650f98ab9)